### PR TITLE
Update to React-Apollo V3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,40 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/react-common": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.0.0.tgz",
+      "integrity": "sha512-EqHASkcmxipy2hU8rja+lD1S1HoTdodKKyJZZ3dgewnAHXnzXnnC3rw1+lkrgXPFsI2n2d2N2LYisD79OCdPmw==",
+      "requires": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@apollo/react-hooks": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.0.0.tgz",
+      "integrity": "sha512-7kaV6rkx2WZjDYcBmp52oyhTxbNn5Jc4AUmsXZVEnDu9uuvNYURA8bLlJNF8yu4zS7ed8D+ZebC0y0bhrz8wIg==",
+      "requires": {
+        "@apollo/react-common": "^3.0.0",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
     "@auth0/auth0-spa-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.1.1.tgz",
@@ -8776,11 +8810,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11075,28 +11104,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
-      }
-    },
-    "react-apollo": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.8.tgz",
-      "integrity": "sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==",
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.2",
-        "tslib": "^1.9.3"
-      }
-    },
-    "react-apollo-hooks": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/react-apollo-hooks/-/react-apollo-hooks-0.5.0.tgz",
-      "integrity": "sha512-Us5KqFe7/c6vY1NaiyfhnD2Pz4lPLTojQXLppShaBVYU/vYvJrRjmj4MzIPXnExXaSfnQ+K2bWDr4lP4efbsRQ==",
-      "requires": {
-        "lodash": "^4.17.11"
       }
     },
     "react-app-polyfill": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@apollo/react-hooks": "^3.0.0",
     "@auth0/auth0-spa-js": "^1.1.1",
     "@material-ui/core": "^4.3.0",
     "@material-ui/icons": "^4.2.1",
@@ -29,8 +30,6 @@
     "i18next": "^17.0.6",
     "i18next-browser-languagedetector": "^3.0.1",
     "react": "^16.8.6",
-    "react-apollo": "^2.5.8",
-    "react-apollo-hooks": "^0.5.0",
     "react-beautiful-dnd": "^11.0.5",
     "react-dom": "^16.8.6",
     "react-i18next": "^10.11.4",

--- a/src/PrivateApp.tsx
+++ b/src/PrivateApp.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Switch, Route } from "react-router";
-import { useQuery } from "react-apollo-hooks";
+import { useQuery } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/styles";
 

--- a/src/components/ContentEditor/ComponentSelector.tsx
+++ b/src/components/ContentEditor/ComponentSelector.tsx
@@ -9,7 +9,7 @@ import {
 import { Grid, Card, Typography, CardContent, Icon } from "@material-ui/core";
 
 import { Draggable } from "react-beautiful-dnd";
-import { useQuery } from "react-apollo-hooks";
+import { useQuery } from "@apollo/react-hooks";
 import { GET_ALL_COMPONENTTYPES } from "queries/componentTypes";
 import BusyOrErrorCard from "components/BusyOrErrorCard";
 import { getAllComponentTypes } from "queries/__generated__/getAllComponentTypes";

--- a/src/components/Discussion.tsx
+++ b/src/components/Discussion.tsx
@@ -16,7 +16,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Comment from "./Comment";
 import { Divider, TextField, Button, Grid } from "@material-ui/core";
 import { subscribeAllComments_comments } from "queries/__generated__/subscribeAllComments";
-import { useMutation } from "react-apollo-hooks";
+import { useMutation } from "@apollo/react-hooks";
 import {
   CREATE_COMMENT,
   RESOLVE_COMMENT,

--- a/src/components/DiscussionList.tsx
+++ b/src/components/DiscussionList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMutation, useSubscription } from "react-apollo-hooks";
+import { useMutation, useSubscription } from "@apollo/react-hooks";
 import { getOperationName, DocumentNode } from "apollo-link";
 import { useSelector } from "react-redux";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { ApolloProvider } from "react-apollo";
-import { ApolloProvider as ApolloHooksProvider } from "react-apollo-hooks";
 import * as Sentry from "@sentry/browser";
 import { Provider } from "react-redux";
+import { ApolloProvider } from "@apollo/react-hooks";
 
 import { ThemeProvider } from "@material-ui/styles";
 
@@ -40,13 +39,11 @@ ReactDOM.render(
       onRedirectCallback={onRedirectCallback}
     >
       <ApolloProvider client={apolloClient}>
-        <ApolloHooksProvider client={apolloClient}>
-          <ThemeProvider theme={theme}>
-            <Router history={myHistory}>
-              <App />
-            </Router>
-          </ThemeProvider>
-        </ApolloHooksProvider>
+        <ThemeProvider theme={theme}>
+          <Router history={myHistory}>
+            <App />
+          </Router>
+        </ThemeProvider>
       </ApolloProvider>
     </AuthProvider>
   </Provider>,

--- a/src/pages/Chapter/Chapter.tsx
+++ b/src/pages/Chapter/Chapter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { RouteComponentProps, Redirect } from "react-router-dom";
-import { useSubscription } from "react-apollo-hooks";
+import { useSubscription } from "@apollo/react-hooks";
 import { useTranslation } from "react-i18next";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";

--- a/src/pages/Chapter/Chapters.tsx
+++ b/src/pages/Chapter/Chapters.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery } from "react-apollo-hooks";
+import { useQuery } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";

--- a/src/pages/Chapter/NewChapter.tsx
+++ b/src/pages/Chapter/NewChapter.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import { Formik, Form, Field, FormikActions } from "formik";
 import { TextField, Select } from "formik-material-ui";
-import { useMutation, useQuery } from "react-apollo-hooks";
+import { useMutation, useQuery } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";

--- a/src/pages/Dashboard/ChapterSection.tsx
+++ b/src/pages/Dashboard/ChapterSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useQuery } from "react-apollo-hooks";
+import { useQuery } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/styles";
 import Grid from "@material-ui/core/Grid";

--- a/src/pages/Dashboard/VoggiSection.tsx
+++ b/src/pages/Dashboard/VoggiSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSubscription } from "react-apollo-hooks";
+import { useSubscription } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/styles";
 import Grid from "@material-ui/core/Grid";

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import * as Yup from "yup";
-import { useQuery, useMutation } from "react-apollo-hooks";
+import { useQuery, useMutation } from "@apollo/react-hooks";
 import { Form, Formik, FormikActions } from "formik";
 
 import { withStyles, WithStyles } from "@material-ui/styles";

--- a/src/pages/SetupWizard/SetupWizard.tsx
+++ b/src/pages/SetupWizard/SetupWizard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Formik, FormikActions, Form } from "formik";
-import { useMutation } from "react-apollo-hooks";
+import { useMutation } from "@apollo/react-hooks";
 
 import Stepper from "@material-ui/core/Stepper";
 import Step from "@material-ui/core/Step";

--- a/src/pages/WordGroup/ChapterWordGroups.tsx
+++ b/src/pages/WordGroup/ChapterWordGroups.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {useTranslation} from "react-i18next";
 
 import {withStyles, WithStyles} from "@material-ui/core/styles";
-import {useQuery} from "react-apollo-hooks";
+import {useQuery} from "@apollo/react-hooks";
 import {RouteComponentProps} from "react-router-dom";
 import Grid from "@material-ui/core/Grid";
 import AddIcon from "@material-ui/icons/Add";

--- a/src/pages/WordGroup/WordEditor.tsx
+++ b/src/pages/WordGroup/WordEditor.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import { Formik, Form, Field, FormikActions } from "formik";
 import { TextField } from "formik-material-ui";
-import { useMutation } from "react-apollo-hooks";
+import { useMutation } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
@@ -44,7 +44,7 @@ const defaultValues = { text: "", audio: "", example_sentence: "" };
 const WordEditor = ({ classes, match, values = defaultValues }: Props) => {
   const { t } = useTranslation();
 
-  // TODO: Unfortunately, react-apollo-hooks doesn't support yet the error, loading object in mutations (unlike with query...)
+  // TODO: Unfortunately, @apollo/react-hooks doesn't support yet the error, loading object in mutations (unlike with query...)
   const [upsertWord] = useMutation(UPSERT_WORD);
 
   async function handleSave(values: any, actions: FormikActions<any>) {

--- a/src/pages/WordGroup/WordGroup.tsx
+++ b/src/pages/WordGroup/WordGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";
-import { useQuery } from "react-apollo-hooks";
+import { useQuery } from "@apollo/react-hooks";
 import { RouteComponentProps } from "react-router-dom";
 import AddIcon from "@material-ui/icons/Add";
 

--- a/src/pages/WordGroup/WordGroupEditor.tsx
+++ b/src/pages/WordGroup/WordGroupEditor.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import { Formik, Form, Field, FormikActions } from "formik";
 import { TextField } from "formik-material-ui";
-import { useMutation } from "react-apollo-hooks";
+import { useMutation } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";

--- a/src/pages/WordGroup/WordGroups.tsx
+++ b/src/pages/WordGroup/WordGroups.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery } from "react-apollo-hooks";
+import { useQuery } from "@apollo/react-hooks";
 
 import { withStyles, WithStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";


### PR DESCRIPTION
The new version with hook support finally has arrived:

https://blog.apollographql.com/apollo-client-now-with-react-hooks-676d116eeae2
https://www.apollographql.com/docs/react/hooks-migration/

Luckily their release is inspired/based on the lib we used for now "react-apollo-hooks", which is now deprecated. So the changes were simple...
