### PR TITLE
Bugfixes for component editing

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -155,7 +155,10 @@ const httpLink = new HttpLink({
 
 const wssUrl =
   (process.env.REACT_APP_BACKEND_URL &&
-    process.env.REACT_APP_BACKEND_URL.replace("https://", "wss://")) ||
+    process.env.REACT_APP_BACKEND_URL.replace("https://", "wss://").replace(
+      "http://",
+      "ws://"
+    )) ||
   "";
 
 // Create a WebSocket link:

--- a/src/components/ContentEditor/Settings.tsx
+++ b/src/components/ContentEditor/Settings.tsx
@@ -170,7 +170,7 @@ const Settings = ({ component, languages, loading }: ISettingsProps) => {
   const classes = useStyles();
   const client = useApolloClient();
   // @ts-ignore
-  let { subChapterId } = useParams();
+  let { chapterId, subChapterId } = useParams();
 
   const [updateComponent, { loading: updateLoading }] = useMutation<
     TupdateComponent,
@@ -263,7 +263,7 @@ const Settings = ({ component, languages, loading }: ISettingsProps) => {
         // Get all native languages of this chapter. Need this to generate the native languages on demand
         const chapter: subscribeChapterById_chapter | null = client.readFragment(
           {
-            id: `api_chapter:${subChapterId}`,
+            id: `api_chapter:${subChapterId || chapterId}`,
             fragment: CHAPTER_HEADER_PART,
           }
         );


### PR DESCRIPTION
This PR fixes a bug introduced by changing to the "chapter without subchapter" change from last meeting. 
Users should now be able to edit components again also in those chapters.

Also fixes a small dev-setup bug when the local hasura URL was not using `https`.